### PR TITLE
Update to add option to ignoreFileExtensions

### DIFF
--- a/packages/manifest/src/pixi.ts
+++ b/packages/manifest/src/pixi.ts
@@ -127,13 +127,8 @@ function collect(
 
         if (!found)
         {
-            result = options.parsers
-                .find((parser) => parser.type === 'copy')
-                ?.parser(
-                    tree as ChildTree,
-                    processor,
-                    options
-                ) as PixiManifestEntry[];
+            result = options.parsers.find(
+                (parser) => parser.type === 'copy')?.parser(tree as ChildTree, processor, options) as PixiManifestEntry[];
         }
 
         const hasIgnoreFileExtensions
@@ -208,7 +203,7 @@ export function defaultPixiParser(tree: ChildTree, processor: Processor, _option
     {
         const name = processor.trimOutputPath(file.name ?? file.paths[0]);
 
-        const res: PixiManifestEntry = {
+        const res: PixiManifestEntry =  {
             name,
             srcs: file.paths.map((path) => processor.trimOutputPath(path)),
         };

--- a/packages/manifest/src/pixi.ts
+++ b/packages/manifest/src/pixi.ts
@@ -182,15 +182,36 @@ function collect(
         {
             if (hasIgnoreFileExtensions)
             {
-                if (
-                    options.ignoreFileExtensions?.some((extensionName) =>
-                        entry.srcs[0].endsWith(extensionName)
-                    )
-                )
+                if (Array.isArray(entry.srcs))
                 {
-                    result.splice(index, 1);
+                    for (const src of entry.srcs)
+                    {
+                        if (
+                            options.ignoreFileExtensions?.some(
+                                (extensionName) => src.endsWith(extensionName)
+                            )
+                        )
+                        {
+                            result.splice(index, 1);
 
-                    return;
+                            return;
+                        }
+                    }
+                }
+                else
+                {
+                    const src = entry.srcs as string;
+
+                    if (
+                        options.ignoreFileExtensions?.some((extensionName) =>
+                            src.endsWith(extensionName)
+                        )
+                    )
+                    {
+                        result.splice(index, 1);
+
+                        return;
+                    }
                 }
             }
 

--- a/packages/manifest/src/pixi.ts
+++ b/packages/manifest/src/pixi.ts
@@ -1,10 +1,4 @@
-import type {
-    ChildTree,
-    Plugin,
-    Processor,
-    RootTree,
-    Tags,
-} from '@assetpack/core';
+import type { ChildTree, Plugin, Processor, RootTree, Tags } from '@assetpack/core';
 import { path, SavableAssetCache } from '@assetpack/core';
 import type { BaseManifestOptions, ManifestParser } from './manifest';
 import { baseManifest } from './manifest';
@@ -35,30 +29,11 @@ export interface PixiManifestOptions extends BaseManifestOptions
     parsers: ManifestParser<any, PixiManifestOptions>[];
 }
 
-export function pixiManifest(
-    options?: Partial<PixiManifestOptions>
-): Plugin<PixiManifestOptions>
+export function pixiManifest(options?: Partial<PixiManifestOptions>): Plugin<PixiManifestOptions>
 {
     const defaultOptions: PixiManifestOptions = {
         createShortcuts: false,
         trimExtensions: false,
-        defaultParser: { type: 'copy', parser: defaultPixiParser },
-        parsers: [],
-        ...options,
-    };
-    const plugin = baseManifest<PixiManifestOptions>(finish, defaultOptions);
-
-    return plugin;
-}
-
-export function pixiManifest2(
-    options?: Partial<PixiManifestOptions>
-): Plugin<PixiManifestOptions>
-{
-    const defaultOptions: PixiManifestOptions = {
-        createShortcuts: false,
-        trimExtensions: false,
-        ignoreFileExtensions: [],
         defaultParser: { type: 'copy', parser: defaultPixiParser },
         parsers: [],
         ...options,
@@ -89,17 +64,11 @@ function finish(
     {
         const nameMap = new Map<PixiManifestEntry, string[]>();
 
-        bundles.forEach((bundle) =>
-            bundle.assets.forEach((asset) =>
-                nameMap.set(asset, asset.name as string[])
-            )
-        );
+        bundles.forEach((bundle) => bundle.assets.forEach((asset) => nameMap.set(asset, asset.name as string[])));
 
         const arrays = Array.from(nameMap.values());
         const sets = arrays.map((arr) => new Set(arr));
-        const uniqueArrays = arrays.map((arr, i) =>
-            arr.filter((x) => sets.every((set, j) => j === i || !set.has(x)))
-        );
+        const uniqueArrays = arrays.map((arr, i) => arr.filter((x) => sets.every((set, j) => j === i || !set.has(x))));
 
         bundles.forEach((bundle) =>
         {
@@ -107,9 +76,7 @@ function finish(
             {
                 const names = nameMap.get(asset) as string[];
 
-                asset.name = uniqueArrays.find((arr) =>
-                    arr.every((x) => names.includes(x))
-                ) as string[];
+                asset.name = uniqueArrays.find((arr) => arr.every((x) => names.includes(x))) as string[];
             });
         });
     }
@@ -133,8 +100,7 @@ function collect(
     // an item may have been deleted, so we don't want to add it to the manifest!
     if (tree.state === 'deleted') return;
 
-    const targetPath
-        = getManifestName(tree.path, processor.config.entry) || 'default';
+    const targetPath = getManifestName(tree.path, processor.config.entry) || 'default';
 
     if (!bundles.has(targetPath))
     {
@@ -153,11 +119,7 @@ function collect(
 
         options.parsers.forEach((parser) =>
         {
-            if (
-                parser.type
-                !== SavableAssetCache.get(tree.path).transformData.type
-            )
-            { return; }
+            if (parser.type !== SavableAssetCache.get(tree.path).transformData.type) return;
             result = parser.parser(tree as ChildTree, processor, options);
 
             found = true;
@@ -217,7 +179,7 @@ function collect(
 
             if (!entry.data?.tags && (Object.keys(tree.fileTags).length > 0 || Object.keys(tree.pathTags).length > 0))
             {
-                entry.data = entry.data || ({} as PixiManifestEntry['data']);
+                entry.data = entry.data || {} as PixiManifestEntry['data'];
                 entry.data!.tags = {
                     ...tree.fileTags,
                     ...tree.pathTags,
@@ -238,11 +200,7 @@ function collect(
     }
 }
 
-export function defaultPixiParser(
-    tree: ChildTree,
-    processor: Processor,
-    _options: PixiManifestOptions
-): PixiManifestEntry[]
+export function defaultPixiParser(tree: ChildTree, processor: Processor, _options: PixiManifestOptions): PixiManifestEntry[]
 {
     const transformData = SavableAssetCache.get(tree.path).transformData;
 
@@ -275,15 +233,13 @@ function getShortNames(name: string | string[], options: PixiManifestOptions)
 
     const allNames = [];
 
-    name = isNameArray ? name[0] : (name as string);
+    name = isNameArray ? name[0] : name as string;
 
     allNames.push(name);
     /* eslint-disable @typescript-eslint/no-unused-expressions */
     trimExtensions && allNames.push(path.trimExt(name));
     createShortcuts && allNames.push(path.basename(name));
-    createShortcuts
-        && trimExtensions
-        && allNames.push(path.trimExt(path.basename(name)));
+    createShortcuts && trimExtensions && allNames.push(path.trimExt(path.basename(name)));
     /* eslint-enable @typescript-eslint/no-unused-expressions */
 
     return allNames;

--- a/packages/manifest/src/pixi.ts
+++ b/packages/manifest/src/pixi.ts
@@ -131,8 +131,7 @@ function collect(
                 (parser) => parser.type === 'copy')?.parser(tree as ChildTree, processor, options) as PixiManifestEntry[];
         }
 
-        const hasIgnoreFileExtensions
-            = options.ignoreFileExtensions !== undefined
+        const hasIgnoreFileExtensions = options.ignoreFileExtensions !== undefined
             && options.ignoreFileExtensions.length > 0;
 
         result.forEach((entry, index) =>
@@ -143,11 +142,7 @@ function collect(
                 {
                     for (const src of entry.srcs)
                     {
-                        if (
-                            options.ignoreFileExtensions?.some(
-                                (extensionName) => src.endsWith(extensionName)
-                            )
-                        )
+                        if (options.ignoreFileExtensions?.some((extensionName) => src.endsWith(extensionName)))
                         {
                             result.splice(index, 1);
 
@@ -159,11 +154,7 @@ function collect(
                 {
                     const src = entry.srcs as string;
 
-                    if (
-                        options.ignoreFileExtensions?.some((extensionName) =>
-                            src.endsWith(extensionName)
-                        )
-                    )
+                    if (options.ignoreFileExtensions?.some((extensionName) => src.endsWith(extensionName)))
                     {
                         result.splice(index, 1);
 


### PR DESCRIPTION


add to `PixiManifestOptions` to make an option to ignore files with the requested file extensions

then to use in our project add the ignoreFileExtensions array in the `assetpack-pixi.js`
<img width="685" alt="Screenshot 2023-11-08 at 10 14 15 am" src="https://github.com/ratimaVGW/assetpack/assets/86645385/5332e662-ebb5-4691-a50d-9e5e35712a21">
